### PR TITLE
Fixed compatibility issues with wx-gtk-3

### DIFF
--- a/SyntaxHighlight.py
+++ b/SyntaxHighlight.py
@@ -48,8 +48,8 @@ class SyntaxHighlight:
             "MethodNames": wx.Colour(0, 7, 255, 255),
             "Keywords": wx.Colour(26, 32, 189, 255),
             "Operators": wx.Colour(210, 147, 29, 255),
-            "TripleQuotes": wx.Color(210, 149, 29, 255),
-            "EdgeLine": wx.Color(255, 0, 22),
+            "TripleQuotes": wx.Colour(210, 149, 29, 255),
+            "EdgeLine": wx.Colour(255, 0, 22),
             }
         self.__color_dict = {}
 

--- a/gEcritPluginManager.py
+++ b/gEcritPluginManager.py
@@ -35,7 +35,7 @@ class gEcritPluginManager(wx.Frame):
                                                         size = (110,40))
         self.remove_pl.Bind(wx.EVT_BUTTON, self.OnDeletePlugin)
 
-        font = wx.Font(18, wx.ROMAN ,wx.BOLD, wx.NORMAL)
+        font = wx.Font(18, wx.FONTFAMILY_ROMAN ,wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL)
         self.pl_list_desc = wx.StaticText(self.main_panel, -1, self._("Plugins:"),
                                                          size = (-1,-1))
         self.pl_list_desc.SetFont(font)


### PR DESCRIPTION
Thanks to these changes, I was able to run gEcrit on Ubuntu Xenial with python 2.7 and python-wxgtk3.0 package installed, before that I had fatal errors
